### PR TITLE
Fix X-UA-Device-force cookie

### DIFF
--- a/devicedetect-dev.vcl
+++ b/devicedetect-dev.vcl
@@ -35,7 +35,6 @@ sub vcl_synth {
 		}
 		set resp.http.Content-Type = "text/html; charset=utf-8";
 		synthetic {"<html><body><h1>OK, Cookie updated</h1><a href='/devicetest/'>/devicetest/</a></body></html>"};
-		set resp.http.response = "OK";
 		return(deliver);
 	}
 }

--- a/devicedetect-dev.vcl
+++ b/devicedetect-dev.vcl
@@ -27,15 +27,15 @@ sub vcl_recv {
 sub vcl_synth {
 	if (resp.status == 701 || resp.status == 702) {
 		if (resp.status == 702) {
-			set resp.status = 200;
 			set resp.http.Set-Cookie = "X-UA-Device-force=expiring; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
-		} else {
 			set resp.status = 200;
-			set resp.http.Set-Cookie = "X-UA-Device-force=" + resp.response + "; Path=/;";
+		} else {
+			set resp.http.Set-Cookie = "X-UA-Device-force=" + resp.reason + "; Path=/;";
+			set resp.status = 200;
 		}
 		set resp.http.Content-Type = "text/html; charset=utf-8";
 		synthetic {"<html><body><h1>OK, Cookie updated</h1><a href='/devicetest/'>/devicetest/</a></body></html>"};
-		set resp.response = "OK";
+		set resp.http.response = "OK";
 		return(deliver);
 	}
 }


### PR DESCRIPTION
Change `resp.response` to `resp.reason` as this is passed to vcl_synth
Change set of `resp.response` to `resp.http.response` (varnish 4)
Setting `resp.status` before using `resp.reason` resets `resp.reason` to "OK" and results in `A-UA-Device-force` cooking being set to "OK". Swap ordering to avoid this.